### PR TITLE
Add clean up for DataSource

### DIFF
--- a/src/main/scala/com/softwaremill/realworld/db/Db.scala
+++ b/src/main/scala/com/softwaremill/realworld/db/Db.scala
@@ -2,13 +2,14 @@ package com.softwaremill.realworld.db
 
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import io.getquill.{SnakeCase, SqliteZioJdbcContext}
-import zio.ZLayer
+import zio.{ZIO, ZLayer}
 
+import java.io.Closeable
 import javax.sql.DataSource
 
 object Db:
 
-  private def create(dbConfig: DbConfig): DataSource = {
+  private def create(dbConfig: DbConfig): HikariDataSource = {
     val poolConfig = new HikariConfig()
     poolConfig.setJdbcUrl(dbConfig.jdbcUrl)
     poolConfig.setConnectionInitSql(dbConfig.connectionInitSql)
@@ -16,7 +17,15 @@ object Db:
   }
 
   // Used for migration and executing queries.
-  val dataSourceLive: ZLayer[DbConfig, Nothing, DataSource] = ZLayer.fromFunction(create(_))
+  val dataSourceLive: ZLayer[DbConfig, Nothing, DataSource] =
+    ZLayer
+      .service[DbConfig]
+      .flatMap { env =>
+        val dbConfig = env.get
+        ZLayer.scoped {
+          ZIO.fromAutoCloseable(ZIO.succeed(create(dbConfig)))
+        }
+      }
 
   // Quill framework object used for specifying sql queries.
   def quillLive: ZLayer[Any, Nothing, SqliteZioJdbcContext[SnakeCase]] = ZLayer.succeed(new SqliteZioJdbcContext[SnakeCase](SnakeCase))


### PR DESCRIPTION
Added clean up for DataSource. Before this change, running full test suite from sbt would leave behind open db connections.