### PR TITLE
dto and db changes in articles

### DIFF
--- a/http_requests/http_requests.http
+++ b/http_requests/http_requests.http
@@ -39,6 +39,22 @@ Authorization: Token {{JWT}}
 
 {
   "article": {
+    "title": "How to train your dragon X",
+    "description": "Ever wonder how?",
+    "body": "You have to believe",
+    "tagList": ["drogon", "fly", "test"]
+  }
+}
+
+###
+
+POST http://localhost:8080/api/articles
+Accept: application/json
+Content-Type: application/json
+Authorization: Token {{JWT}}
+
+{
+  "article": {
     "title": "How to train your dragon VI",
     "description": "Ever wonder how?",
     "body": "You have to believe"
@@ -121,3 +137,38 @@ Authorization: Token {{JWT}}
     "bio": "changed bio"
   }
 }
+
+###
+
+POST http://localhost:8080/api/articles/how-to-train-your-dragon-x/favorite
+Accept: application/json
+Content-Type: application/json
+Authorization: Token {{JWT}}
+
+###
+
+DELETE http://localhost:8080/api/articles/how-to-train-your-dragon-x/favorite
+Accept: application/json
+Content-Type: application/json
+Authorization: Token {{JWT}}
+
+###
+
+POST http://localhost:8080/api/articles/how-to-train-your-dragon-x/comments
+Accept: application/json
+Content-Type: application/json
+Authorization: Token {{JWT}}
+
+{
+  "comment": {
+    "body": "His name was my name too."
+  }
+}
+
+###
+
+DELETE http://localhost:8080/api/articles/how-to-train-your-dragon-x/comments/1
+Accept: application/json
+Content-Type: application/json
+Authorization: Token {{JWT}}
+

--- a/src/main/resources/db/migration/V1_1__init.sql
+++ b/src/main/resources/db/migration/V1_1__init.sql
@@ -17,8 +17,9 @@ CREATE TABLE followers
 
 CREATE TABLE articles
 (
-    slug        TEXT PRIMARY KEY,
-    title       TEXT    NOT NULL,
+    article_id  INTEGER PRIMARY KEY,
+    slug        TEXT    NOT NULL UNIQUE,
+    title       TEXT    NOT NULL UNIQUE,
     description TEXT,
     body        TEXT    NOT NULL,
     created_at  INTEGER NOT NULL,
@@ -29,27 +30,27 @@ CREATE TABLE articles
 
 CREATE TABLE tags_articles
 (
-    tag          TEXT NOT NULL,
-    article_slug TEXT NOT NULL,
-    FOREIGN KEY (article_slug) REFERENCES articles (slug) ON UPDATE CASCADE,
-    PRIMARY KEY (tag, article_slug)
+    tag        TEXT NOT NULL,
+    article_id INTEGER NOT NULL,
+    FOREIGN KEY (article_id) REFERENCES articles (article_id) ON UPDATE CASCADE,
+    PRIMARY KEY (tag, article_id)
 );
 
 CREATE TABLE favorites_articles
 (
-    profile_id   INTEGER NOT NULL,
-    article_slug TEXT    NOT NULL,
-    FOREIGN KEY (article_slug) REFERENCES articles (slug) ON UPDATE CASCADE,
+    profile_id INTEGER NOT NULL,
+    article_id INTEGER NOT NULL,
+    FOREIGN KEY (article_id) REFERENCES articles (article_id) ON UPDATE CASCADE,
     FOREIGN KEY (profile_id) REFERENCES users (user_id),
-    PRIMARY KEY (profile_id, article_slug)
+    PRIMARY KEY (profile_id, article_id)
 );
 
 CREATE TABLE comments_articles
 (
-    comment_id   INTEGER PRIMARY KEY,
-    article_slug TEXT    NOT NULL REFERENCES articles (slug) ON UPDATE CASCADE,
-    created_at   INTEGER NOT NULL,
-    updated_at   INTEGER NOT NULL,
-    author_id    INTEGER NOT NULL REFERENCES users (user_id),
-    body         TEXT    NOT NULL
+    comment_id INTEGER PRIMARY KEY,
+    article_id INTEGER NOT NULL REFERENCES articles (article_id) ON UPDATE CASCADE,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    author_id  INTEGER NOT NULL REFERENCES users (user_id),
+    body       TEXT    NOT NULL
 )

--- a/src/main/scala/com/softwaremill/realworld/articles/ArticlesRepository.scala
+++ b/src/main/scala/com/softwaremill/realworld/articles/ArticlesRepository.scala
@@ -8,13 +8,15 @@ import com.softwaremill.realworld.common.{Exceptions, Pagination}
 import com.softwaremill.realworld.profiles.ProfileRow
 import com.softwaremill.realworld.users.UserRow
 import io.getquill.*
+import org.sqlite.SQLiteErrorCode.SQLITE_CONSTRAINT_UNIQUE
 import org.sqlite.{SQLiteErrorCode, SQLiteException}
-import zio.{Console, IO, Task, UIO, ZIO, ZLayer}
+import zio.{Console, IO, RIO, Task, UIO, ZIO, ZLayer}
 
 import java.sql.SQLException
 import java.time.Instant
 import javax.sql.DataSource
 import scala.collection.immutable
+import scala.util.chaining.*
 
 class ArticlesRepository(quill: SqliteZioJdbcContext[SnakeCase], dataSource: DataSource):
 
@@ -35,12 +37,12 @@ class ArticlesRepository(quill: SqliteZioJdbcContext[SnakeCase], dataSource: Dat
     val authorFilter = filters.getOrElse(Author, "")
     run(for {
       ar <- sql"""
-                     SELECT a.slug, a.title, a.description, a.body, a.created_at, a.updated_at, a.author_id
+                     SELECT a.article_id, a.slug, a.title, a.description, a.body, a.created_at, a.updated_at, a.author_id
                      FROM articles a
                      LEFT JOIN users authors ON authors.user_id = a.author_id
-                     LEFT JOIN favorites_articles fa ON fa.article_slug = a.slug
+                     LEFT JOIN favorites_articles fa ON fa.article_id = a.article_id
                      LEFT JOIN users fu ON fu.user_id = fa.profile_id
-                     LEFT JOIN tags_articles ta ON a.slug = ta.article_slug
+                     LEFT JOIN tags_articles ta ON a.article_id = ta.article_id
                      WHERE (${lift(tagFilter)} = '' OR ${lift(tagFilter)} = ta.tag)
                           AND (${lift(favoritedFilter)} = '' OR ${lift(favoritedFilter)} = fu.username)
                           AND (${lift(authorFilter)} = '' OR ${lift(authorFilter)} = authors.username)
@@ -51,11 +53,11 @@ class ArticlesRepository(quill: SqliteZioJdbcContext[SnakeCase], dataSource: Dat
         .take(lift(pagination.limit))
         .sortBy(ar => ar.slug)
       tr <- queryTagArticle
-        .groupByMap(_.articleSlug)(atr => (atr.articleSlug, tagsConcat(atr.tag)))
-        .leftJoin(a => a._1 == ar.slug)
+        .groupByMap(_.articleId)(atr => (atr.articleId, tagsConcat(atr.tag)))
+        .leftJoin(a => a._1 == ar.articleId)
       fr <- queryFavoriteArticle
-        .groupByMap(_.articleSlug)(fr => (fr.articleSlug, count(fr.profileId)))
-        .leftJoin(f => f._1 == ar.slug)
+        .groupByMap(_.articleId)(fr => (fr.articleId, count(fr.profileId)))
+        .leftJoin(f => f._1 == ar.articleId)
       pr <- queryProfile if ar.authorId == pr.userId
     } yield (ar, pr, tr.map(_._2), fr.map(_._2)))
       .map(_.map(article))
@@ -66,29 +68,42 @@ class ArticlesRepository(quill: SqliteZioJdbcContext[SnakeCase], dataSource: Dat
     run(for {
       ar <- queryArticle if ar.slug == lift(slug)
       tr <- queryTagArticle
-        .groupByMap(_.articleSlug)(atr => (atr.articleSlug, tagsConcat(atr.tag)))
-        .leftJoin(a => a._1 == ar.slug)
+        .groupByMap(_.articleId)(atr => (atr.articleId, tagsConcat(atr.tag)))
+        .leftJoin(a => a._1 == ar.articleId)
       fr <- queryFavoriteArticle
-        .groupByMap(_.articleSlug)(fr => (fr.articleSlug, count(fr.profileId)))
-        .leftJoin(f => f._1 == ar.slug)
+        .groupByMap(_.articleId)(fr => (fr.articleId, count(fr.profileId)))
+        .leftJoin(f => f._1 == ar.articleId)
       pr <- queryProfile if ar.authorId == pr.userId
     } yield (ar, pr, tr.map(_._2), fr.map(_._2), false))
       .map(_.headOption)
       .map(_.map(mapToArticleData))
       .provide(dsLayer)
 
+  def findArticleIdBySlug(slug: String): Task[Int] =
+    run(
+      queryArticle
+        .filter(a => a.slug == lift(slug))
+        .map(_.articleId)
+    )
+      .map(_.headOption)
+      .flatMap {
+        case Some(a) => ZIO.succeed(a)
+        case None    => ZIO.fail(Exceptions.NotFound(s"Article with slug $slug doesn't exist."))
+      }
+      .provide(dsLayer)
+
   def findBySlugAsSeenBy(slug: String, viewerEmail: String): IO[SQLException, Option[ArticleData]] =
     run(for {
       ar <- queryArticle if ar.slug == lift(slug)
       tr <- queryTagArticle
-        .groupByMap(_.articleSlug)(atr => (atr.articleSlug, tagsConcat(atr.tag)))
-        .leftJoin(a => a._1 == ar.slug)
+        .groupByMap(_.articleId)(atr => (atr.articleId, tagsConcat(atr.tag)))
+        .leftJoin(a => a._1 == ar.articleId)
       fr <- queryFavoriteArticle
-        .groupByMap(_.articleSlug)(fr => (fr.articleSlug, count(fr.profileId)))
-        .leftJoin(f => f._1 == ar.slug)
+        .groupByMap(_.articleId)(fr => (fr.articleId, count(fr.profileId)))
+        .leftJoin(f => f._1 == ar.articleId)
       isFavorite = queryUser
         .join(queryFavoriteArticle)
-        .on((u, f) => u.email == lift(viewerEmail) && (f.articleSlug == ar.slug) && (f.profileId == u.userId))
+        .on((u, f) => u.email == lift(viewerEmail) && (f.articleId == ar.articleId) && (f.profileId == u.userId))
         .map(_ => 1)
         .nonEmpty
       pr <- queryProfile if ar.authorId == pr.userId
@@ -97,55 +112,83 @@ class ArticlesRepository(quill: SqliteZioJdbcContext[SnakeCase], dataSource: Dat
       .map(_.map(mapToArticleData))
       .provide(dsLayer)
 
-  def addTag(tag: String, slug: String): IO[Exception, Unit] = run(
+  def findBySlugAsSeenBy(articleId: Int, viewerEmail: String): IO[SQLException, Option[ArticleData]] =
+    run(for {
+      ar <- queryArticle if ar.articleId == lift(articleId)
+      tr <- queryTagArticle
+        .groupByMap(_.articleId)(atr => (atr.articleId, tagsConcat(atr.tag)))
+        .leftJoin(a => a._1 == ar.articleId)
+      fr <- queryFavoriteArticle
+        .groupByMap(_.articleId)(fr => (fr.articleId, count(fr.profileId)))
+        .leftJoin(f => f._1 == ar.articleId)
+      isFavorite = queryUser
+        .join(queryFavoriteArticle)
+        .on((u, f) => u.email == lift(viewerEmail) && (f.articleId == ar.articleId) && (f.profileId == u.userId))
+        .map(_ => 1)
+        .nonEmpty
+      pr <- queryProfile if ar.authorId == pr.userId
+    } yield (ar, pr, tr.map(_._2), fr.map(_._2), isFavorite))
+      .map(_.headOption)
+      .map(_.map(mapToArticleData))
+      .provide(dsLayer)
+
+  def addTag(tag: String, articleId: Int): IO[Exception, Unit] = run(
     queryTagArticle
       .insert(
         _.tag -> lift(tag),
-        _.articleSlug -> lift(slug)
+        _.articleId -> lift(articleId)
       )
   ).unit
     .provide(dsLayer)
 
-  def add(article: ArticleRow): Task[Unit] =
-    run(queryArticle.insertValue(lift(article))).unit
-      .mapError {
-        case e: SQLiteException if e.getResultCode == SQLiteErrorCode.SQLITE_CONSTRAINT_PRIMARYKEY =>
-          Exceptions.AlreadyInUse("Article name already exists")
-        case e => e
-      }
+  def add(createData: ArticleCreateData, userId: Int): Task[Int] = {
+    val now = Instant.now()
+    run(
+      queryArticle
+        .insert(
+          _.slug -> lift(createData.title.trim.toLowerCase.replace(" ", "-")),
+          _.title -> lift(createData.title.trim),
+          _.description -> lift(createData.description),
+          _.body -> lift(createData.body),
+          _.createdAt -> lift(now),
+          _.updatedAt -> lift(now),
+          _.authorId -> lift(userId)
+        )
+        .returning(_.articleId)
+    )
+      .pipe(mapUniqueConstraintViolationError)
       .provide(dsLayer)
+  }
 
-  def updateBySlug(updateData: ArticleData, slug: String): IO[Exception, Unit] = run(
+  def updateById(updateData: ArticleData, articleId: Int): Task[Unit] = run(
     queryArticle
-      .filter(_.slug == lift(slug.toLowerCase()))
+      .filter(_.articleId == lift(articleId))
       .update(
         record => record.slug -> lift(updateData.slug),
         record => record.title -> lift(updateData.title),
         record => record.description -> lift(updateData.description),
-        record => record.body -> lift(updateData.body)
+        record => record.body -> lift(updateData.body),
+        record => record.updatedAt -> lift(updateData.updatedAt)
       )
   ).unit
-    .mapError {
-      case e: SQLiteException if e.getResultCode == SQLiteErrorCode.SQLITE_CONSTRAINT_PRIMARYKEY =>
-        Exceptions.AlreadyInUse("Article name already exists")
-      case e => e
-    }
+    .pipe(mapUniqueConstraintViolationError)
     .provide(dsLayer)
 
-  def makeFavorite(slug: String, userId: Int) = run(
-    queryFavoriteArticle.insertValue(lift(ArticleFavoriteRow(userId, slug))).onConflictIgnore
-  ).unit.provide(dsLayer)
+  def makeFavorite(articleId: Int, userId: Int): Task[Unit] = run(
+    queryFavoriteArticle.insertValue(lift(ArticleFavoriteRow(userId, articleId))).onConflictIgnore
+  ).unit
+    .provide(dsLayer)
 
-  def removeFavorite(slug: String, userId: Int) = run(
-    queryFavoriteArticle.filter(a => (a.profileId == lift(userId)) && (a.articleSlug == lift(slug))).delete
+  def removeFavorite(articleId: Int, userId: Int): Task[Long] = run(
+    queryFavoriteArticle.filter(a => (a.profileId == lift(userId)) && (a.articleId == lift(articleId))).delete
   ).provide(dsLayer)
 
-  def addComment(slug: String, authorId: Int, comment: String) = {
+  def addComment(articleId: Int, authorId: Int, comment: String): Task[Index] = {
     val now = Instant.now()
     run {
       queryCommentArticle
         .insert(
-          _.articleSlug -> lift(slug),
+          _.articleId -> lift(articleId),
           _.createdAt -> lift(now),
           _.updatedAt -> lift(now),
           _.authorId -> lift(authorId),
@@ -155,12 +198,14 @@ class ArticlesRepository(quill: SqliteZioJdbcContext[SnakeCase], dataSource: Dat
     }.provide(dsLayer)
   }
 
-  def findComment(commentId: Int) = run(queryCommentArticle.filter(_.commentId == lift(commentId)))
-    .map(_.headOption)
-    .provide(dsLayer)
-    .someOrFail(Exceptions.NotFound(s"Comment with ID=$commentId doesn't exist"))
+  def findComment(commentId: Int): Task[CommentRow] =
+    run(queryCommentArticle.filter(_.commentId == lift(commentId)))
+      .map(_.headOption)
+      .provide(dsLayer)
+      .someOrFail(Exceptions.NotFound(s"Comment with ID=$commentId doesn't exist"))
 
-  def deleteComment(commentId: Int) = run(queryCommentArticle.filter(_.commentId == lift(commentId)).delete).provide(dsLayer)
+  def deleteComment(commentId: Int): Task[Long] =
+    run(queryCommentArticle.filter(_.commentId == lift(commentId)).delete).provide(dsLayer)
 
   private def article(tuple: (ArticleRow, ProfileRow, Option[String], Option[Int])): ArticleData = {
     val (ar, pr, tags, favorites) = tuple
@@ -195,6 +240,12 @@ class ArticlesRepository(quill: SqliteZioJdbcContext[SnakeCase], dataSource: Dat
         // TODO implement "following" (after authentication is ready)
         ArticleAuthor(pr.username, Option(pr.bio), Option(pr.image), following = false)
       )
+  }
+
+  private def mapUniqueConstraintViolationError[R, A](task: RIO[R, A]): RIO[R, A] = task.mapError {
+    case e: SQLiteException if e.getResultCode == SQLITE_CONSTRAINT_UNIQUE =>
+      Exceptions.AlreadyInUse("Article name already exists")
+    case e => e
   }
 
 object ArticlesRepository:

--- a/src/main/scala/com/softwaremill/realworld/articles/ArticlesService.scala
+++ b/src/main/scala/com/softwaremill/realworld/articles/ArticlesService.scala
@@ -25,27 +25,20 @@ class ArticlesService(articlesRepository: ArticlesRepository, usersRepository: U
       case None    => ZIO.fail(Exceptions.NotFound(s"Article with slug $slug doesn't exist."))
     }
 
+  def findBySlugAsSeenBy(articleId: Int, email: String): IO[Exception, ArticleData] = articlesRepository
+    .findBySlugAsSeenBy(articleId, email)
+    .flatMap {
+      case Some(a) => ZIO.succeed(a)
+      case None    => ZIO.fail(Exceptions.NotFound(s"Article doesn't exist."))
+    }
+
   def create(createData: ArticleCreateData, userEmail: String): Task[ArticleData] =
     for {
       user <- userByEmail(userEmail)
-      newArticle = createArticleRow(createData, user)
-      _ <- articlesRepository.add(newArticle)
-      _ <- ZIO.foreach(createData.tagList)(tag => articlesRepository.addTag(tag, newArticle.slug))
-      articleData <- findBySlugAsSeenBy(newArticle.slug, userEmail)
+      articleId <- articlesRepository.add(createData, user.userId)
+      _ <- ZIO.foreach(createData.tagList)(tag => articlesRepository.addTag(tag, articleId))
+      articleData <- findBySlugAsSeenBy(articleId, userEmail)
     } yield articleData
-
-  private def createArticleRow(createData: ArticleCreateData, userRow: UserRow): ArticleRow = {
-    val now = Instant.now()
-    ArticleRow(
-      slug = createData.title.trim.toLowerCase.replace(" ", "-"),
-      title = createData.title.trim,
-      description = createData.description,
-      body = createData.body,
-      createdAt = now,
-      updatedAt = now,
-      authorId = userRow.userId
-    )
-  }
 
   def update(articleUpdateData: ArticleUpdateData, slug: String, email: String): Task[ArticleData] =
     for {
@@ -56,7 +49,8 @@ class ArticlesService(articlesRepository: ArticlesRepository, usersRepository: U
         .fail(Unauthorized(s"You're not an author of article that you're trying to update"))
         .when(user.username != oldArticle.author.username)
       updatedArticle = updateArticleData(oldArticle, articleUpdateData)
-      _ <- articlesRepository.updateBySlug(updatedArticle, oldArticle.slug)
+      articleId <- articlesRepository.findArticleIdBySlug(slug)
+      _ <- articlesRepository.updateById(updatedArticle, articleId)
     } yield updatedArticle
 
   private def updateArticleData(articleData: ArticleData, updatedData: ArticleUpdateData): ArticleData = {
@@ -68,19 +62,22 @@ class ArticlesService(articlesRepository: ArticlesRepository, usersRepository: U
         .getOrElse(articleData.slug),
       title = updatedData.title.map(_.trim).getOrElse(articleData.title),
       description = updatedData.description.getOrElse(articleData.description),
-      body = updatedData.body.getOrElse(articleData.body)
+      body = updatedData.body.getOrElse(articleData.body),
+      updatedAt = Instant.now()
     )
   }
 
   def makeFavorite(slug: String, email: String): Task[ArticleData] = for {
     user <- userByEmail(email)
-    _ <- articlesRepository.makeFavorite(slug, user.userId)
+    articleId <- articlesRepository.findArticleIdBySlug(slug)
+    _ <- articlesRepository.makeFavorite(articleId, user.userId)
     articleData <- findBySlugAsSeenBy(slug, email)
   } yield articleData
 
   def removeFavorite(slug: String, email: String): Task[ArticleData] = for {
     user <- userByEmail(email)
-    _ <- articlesRepository.removeFavorite(slug, user.userId)
+    articleId <- articlesRepository.findArticleIdBySlug(slug)
+    _ <- articlesRepository.removeFavorite(articleId, user.userId)
     articleData <- findBySlugAsSeenBy(slug, email)
   } yield articleData
 
@@ -89,15 +86,17 @@ class ArticlesService(articlesRepository: ArticlesRepository, usersRepository: U
 
   def addComment(slug: String, email: String, comment: String): Task[CommentData] = for {
     user <- userByEmail(email)
-    id <- articlesRepository.addComment(slug, user.userId, comment)
+    articleId <- articlesRepository.findArticleIdBySlug(slug)
+    id <- articlesRepository.addComment(articleId, user.userId, comment)
     row <- articlesRepository.findComment(id)
     profile <- profilesService.getProfileData(row.authorId, user.userId)
   } yield CommentData(row.commentId, row.createdAt, row.updatedAt, row.body, profile)
 
   def deleteComment(slug: String, email: String, commentId: Int): Task[Unit] = for {
     user <- userByEmail(email)
+    articleId <- articlesRepository.findArticleIdBySlug(slug)
     comment <- articlesRepository.findComment(commentId)
-    _ <- ZIO.fail(BadRequest(s"Comment with ID=$commentId is not linked to slug $slug")).when(comment.articleSlug != slug)
+    _ <- ZIO.fail(BadRequest(s"Comment with ID=$commentId is not linked to slug $slug")).when(comment.articleId != articleId)
     _ <- ZIO.fail(Unauthorized("Can't remove the comment you're not an author of")).when(user.userId != comment.authorId)
     _ <- articlesRepository.deleteComment(commentId)
   } yield ()

--- a/src/main/scala/com/softwaremill/realworld/articles/comments/CommentRow.scala
+++ b/src/main/scala/com/softwaremill/realworld/articles/comments/CommentRow.scala
@@ -2,4 +2,4 @@ package com.softwaremill.realworld.articles.comments
 
 import java.time.Instant
 
-case class CommentRow(commentId: Int, articleSlug: String, createdAt: Instant, updatedAt: Instant, authorId: Int, body: String)
+case class CommentRow(commentId: Int, articleId: Int, createdAt: Instant, updatedAt: Instant, authorId: Int, body: String)

--- a/src/main/scala/com/softwaremill/realworld/articles/model/ArticleFavoriteRow.scala
+++ b/src/main/scala/com/softwaremill/realworld/articles/model/ArticleFavoriteRow.scala
@@ -1,3 +1,3 @@
 package com.softwaremill.realworld.articles.model
 
-case class ArticleFavoriteRow(profileId: Int, articleSlug: String)
+case class ArticleFavoriteRow(profileId: Int, articleId: Int)

--- a/src/main/scala/com/softwaremill/realworld/articles/model/ArticleRow.scala
+++ b/src/main/scala/com/softwaremill/realworld/articles/model/ArticleRow.scala
@@ -3,6 +3,7 @@ package com.softwaremill.realworld.articles.model
 import java.time.Instant
 
 case class ArticleRow(
+    articleId: Int,
     slug: String,
     title: String,
     description: String,

--- a/src/main/scala/com/softwaremill/realworld/articles/model/ArticleTagRow.scala
+++ b/src/main/scala/com/softwaremill/realworld/articles/model/ArticleTagRow.scala
@@ -1,3 +1,3 @@
 package com.softwaremill.realworld.articles.model
 
-case class ArticleTagRow(tag: String, articleSlug: String)
+case class ArticleTagRow(tag: String, articleId: Int)

--- a/src/main/scala/com/softwaremill/realworld/articles/model/ArticleUpdateData.scala
+++ b/src/main/scala/com/softwaremill/realworld/articles/model/ArticleUpdateData.scala
@@ -5,7 +5,6 @@ import com.softwaremill.realworld.common.NoneAsNullOptionEncoder.*
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 
 case class ArticleUpdateData(
-    slug: Option[String], // TODO add additional class without slug
     title: Option[String],
     description: Option[String],
     body: Option[String]

--- a/src/test/resources/fixtures/articles/basic-data.sql
+++ b/src/test/resources/fixtures/articles/basic-data.sql
@@ -5,22 +5,22 @@ VALUES (10, 'jake@example.com', 'jake', 'secret password', 'I work at statefarm'
 INSERT INTO followers (user_id, follower_id) VALUES (10, 20); 
 
 INSERT INTO articles
-VALUES ('how-to-train-your-dragon', 'How to train your dragon', 'Ever wonder how?', 'It takes a Jacobian',
+VALUES (1, 'how-to-train-your-dragon', 'How to train your dragon', 'Ever wonder how?', 'It takes a Jacobian',
         1455765776637, 1455767315824, 10),
-       ('how-to-train-your-dragon-2', 'How to train your dragon 2', 'So toothless', 'Its a dragon', 1455765776637,
+       (2, 'how-to-train-your-dragon-2', 'How to train your dragon 2', 'So toothless', 'Its a dragon', 1455765776637,
         1455767315824, 10),
-       ('how-to-train-your-dragon-3', 'How to train your dragon 3', 'The tagless one', 'Its not a dragon', 1455765776637,
+       (3, 'how-to-train-your-dragon-3', 'How to train your dragon 3', 'The tagless one', 'Its not a dragon', 1455765776637,
         1455767315824, 20);
 
 INSERT INTO tags_articles
-VALUES ('dragons', 'how-to-train-your-dragon'),
-       ('training', 'how-to-train-your-dragon'),
-       ('dragons', 'how-to-train-your-dragon-2'),
-       ('goats', 'how-to-train-your-dragon-2'),
-       ('training', 'how-to-train-your-dragon-2');
+VALUES ('dragons', 1),
+       ('training', 1),
+       ('dragons', 2),
+       ('goats', 2),
+       ('training', 2);
 
 INSERT INTO favorites_articles
-VALUES (10, 'how-to-train-your-dragon'),
-       (20, 'how-to-train-your-dragon'),
-       (20, 'how-to-train-your-dragon-2');
+VALUES (10, 1),
+       (20, 1),
+       (20, 2);
 

--- a/src/test/scala/com/softwaremill/realworld/articles/ArticlesEndpointsSpec.scala
+++ b/src/test/scala/com/softwaremill/realworld/articles/ArticlesEndpointsSpec.scala
@@ -292,31 +292,20 @@ object ArticlesEndpointsSpec extends ZIOSpecDefault:
       test("article creation - check conflict") {
         assertZIO(for {
           repo <- ZIO.service[ArticlesRepository]
-          _ <- repo.add(
-            ArticleRow(
-              slug = "test-slug",
-              title = "title",
-              description = "description",
-              body = "body",
-              createdAt = Instant.now,
-              updatedAt = Instant.now,
-              authorId = 1
-            )
+          createData = ArticleCreateData(
+            title = "Test slug",
+            description = "So toothless",
+            body = "Its a dragon",
+            tagList = List("drogon", "fly")
           )
+          _ <- repo.add(createData = createData, userId = 1)
           articlesEndpoints <- ZIO.service[ArticlesEndpoints]
           endpoint = articlesEndpoints.create
           authHeader <- getValidAuthorizationHeader()
           response <- basicRequest
             .post(uri"http://test.com/api/articles")
             .body(
-              ArticleCreate(
-                ArticleCreateData(
-                  title = "Test slug",
-                  description = "So toothless",
-                  body = "Its a dragon",
-                  tagList = List("drogon", "fly")
-                )
-              )
+              ArticleCreate(createData)
             )
             .headers(authHeader)
             .response(asJson[Article])
@@ -350,15 +339,13 @@ object ArticlesEndpointsSpec extends ZIOSpecDefault:
         for {
           repo <- ZIO.service[ArticlesRepository]
           _ <- repo.add(
-            ArticleRow(
-              slug = "test-slug",
+            ArticleCreateData(
               title = "Test slug",
               description = "description",
               body = "body",
-              createdAt = Instant.now,
-              updatedAt = Instant.now,
-              authorId = 1
-            )
+              tagList = List()
+            ),
+            1
           )
           articlesEndpoints <- ZIO.service[ArticlesEndpoints]
           endpoint = articlesEndpoints.update
@@ -368,7 +355,6 @@ object ArticlesEndpointsSpec extends ZIOSpecDefault:
             .body(
               ArticleUpdate(
                 ArticleUpdateData(
-                  slug = Option("test-slug-2"),
                   title = Option("Test slug 2"),
                   description = Option("updated description"),
                   body = Option("updated body")
@@ -406,26 +392,22 @@ object ArticlesEndpointsSpec extends ZIOSpecDefault:
           for {
             repo <- ZIO.service[ArticlesRepository]
             _ <- repo.add(
-              ArticleRow(
-                slug = "test-slug",
+              ArticleCreateData(
                 title = "Test slug",
                 description = "description",
                 body = "body",
-                createdAt = Instant.now,
-                updatedAt = Instant.now,
-                authorId = 1
-              )
+                tagList = List()
+              ),
+              1
             )
             _ <- repo.add(
-              ArticleRow(
-                slug = "test-slug-2",
+              ArticleCreateData(
                 title = "Test slug 2",
                 description = "description",
                 body = "body",
-                createdAt = Instant.now,
-                updatedAt = Instant.now,
-                authorId = 1
-              )
+                tagList = List()
+              ),
+              1
             )
             articlesEndpoints <- ZIO.service[ArticlesEndpoints]
             endpoint = articlesEndpoints.update
@@ -435,7 +417,6 @@ object ArticlesEndpointsSpec extends ZIOSpecDefault:
               .body(
                 ArticleUpdate(
                   ArticleUpdateData(
-                    slug = Option("test-slug-2"),
                     title = Option("Test slug 2"),
                     description = Option("updated description"),
                     body = Option("updated body")

--- a/src/test/scala/com/softwaremill/realworld/common/AuthorizationSpec.scala
+++ b/src/test/scala/com/softwaremill/realworld/common/AuthorizationSpec.scala
@@ -103,6 +103,26 @@ object AuthorizationSpec extends ZIOSpecDefault:
       endpointParam = ArticleAuthEndpointParameters.removeFavorite("slug"),
       headers = Map(),
       expectedError = "Invalid value for: header Authorization (missing)"
+    ),
+    ArticleAuthTestParameters(
+      endpointParam = ArticleAuthEndpointParameters.addComment("slug"),
+      headers = Map("Authorization" -> "Token Invalid JWT"),
+      expectedError = "{\"error\":\"Invalid token!\"}"
+    ),
+    ArticleAuthTestParameters(
+      endpointParam = ArticleAuthEndpointParameters.addComment("slug"),
+      headers = Map(),
+      expectedError = "Invalid value for: header Authorization (missing)"
+    ),
+    ArticleAuthTestParameters(
+      endpointParam = ArticleAuthEndpointParameters.deleteComment("slug", 1),
+      headers = Map("Authorization" -> "Token Invalid JWT"),
+      expectedError = "{\"error\":\"Invalid token!\"}"
+    ),
+    ArticleAuthTestParameters(
+      endpointParam = ArticleAuthEndpointParameters.deleteComment("slug", 1),
+      headers = Map(),
+      expectedError = "Invalid value for: header Authorization (missing)"
     )
   )
 

--- a/src/test/scala/com/softwaremill/realworld/common/model/DiffDefinitions.scala
+++ b/src/test/scala/com/softwaremill/realworld/common/model/DiffDefinitions.scala
@@ -13,7 +13,11 @@ object UserWithPasswordDiff:
   given UserWithPasswordDiff: Diff[UserWithPassword] = Diff.derived[UserWithPassword].ignore(_.hashedPassword)
 
 object ArticleDiff:
+  given articleDiff: Diff[Article] = Diff.derived[Article]
+  given articleDataDiff: Diff[ArticleData] = Diff.derived[ArticleData].ignore(_.createdAt).ignore(_.updatedAt)
+  given articleAuthorDiff: Diff[ArticleAuthor] = Diff.derived[ArticleAuthor]
 
+object ArticleDiffWithSameCreateAt:
   given articleDiff: Diff[Article] = Diff.derived[Article]
   given articleDataDiff: Diff[ArticleData] = Diff.derived[ArticleData].ignore(_.createdAt).ignore(_.updatedAt)
   given articleAuthorDiff: Diff[ArticleAuthor] = Diff.derived[ArticleAuthor]

--- a/src/test/scala/com/softwaremill/realworld/common/model/auth/ArticleAuthTestParameters.scala
+++ b/src/test/scala/com/softwaremill/realworld/common/model/auth/ArticleAuthTestParameters.scala
@@ -45,3 +45,11 @@ object ArticleAuthEndpointParameters:
     endpoint = ZIO.service[ArticlesEndpoints].map(endpoints => endpoints.removeFavorite),
     request = basicRequest.delete(uri"http://test.com/api/articles/$slug/favorite")
   )
+  def addComment(slug: String): ArticleAuthEndpointParameters = ArticleAuthEndpointParameters(
+    endpoint = ZIO.service[ArticlesEndpoints].map(endpoints => endpoints.addComment),
+    request = basicRequest.post(uri"http://test.com/api/articles/$slug/comments")
+  )
+  def deleteComment(slug: String, commentId: Int): ArticleAuthEndpointParameters = ArticleAuthEndpointParameters(
+    endpoint = ZIO.service[ArticlesEndpoints].map(endpoints => endpoints.deleteComment),
+    request = basicRequest.delete(uri"http://test.com/api/articles/$slug/comments/$commentId")
+  )


### PR DESCRIPTION
It wasn't good idea that slug was primary key of the article. It was used as foreign key in several tables, but realworld spec allows updating it in update article endpoint.
It caused many troubles with dependent tables (tags/comments/favorites etc)