### PR TITLE
Order articles by newest first

### DIFF
--- a/src/main/scala/com/softwaremill/realworld/articles/core/ArticlesRepository.scala
+++ b/src/main/scala/com/softwaremill/realworld/articles/core/ArticlesRepository.scala
@@ -103,11 +103,11 @@ class ArticlesRepository(quill: Quill.Sqlite[SnakeCase]):
                SELECT DISTINCT * FROM articles a
                WHERE a.author_id IN (SELECT f.user_id FROM followers f
                                      WHERE f.follower_id = ${lift(viewerId)})
+               ORDER BY a.created_at DESC
              """
         .as[Query[ArticleRow]]
         .drop(lift(pagination.offset))
         .take(lift(pagination.limit))
-        .sortBy(ar => ar.slug)
     }
 
     val articleQuery = buildArticleQueryWithFavoriteAndFollowing(articleRow, viewerId)

--- a/src/main/scala/com/softwaremill/realworld/articles/core/ArticlesRepository.scala
+++ b/src/main/scala/com/softwaremill/realworld/articles/core/ArticlesRepository.scala
@@ -78,11 +78,11 @@ class ArticlesRepository(quill: Quill.Sqlite[SnakeCase]):
                     AND (${lift(favoritedFilter)} = '' OR ${lift(favoritedFilter)} = fu.username)
                     AND (${lift(authorFilter)} = '' OR ${lift(authorFilter)} = authors.username)
                GROUP BY a.slug, a.title, a.description, a.body, a.created_at, a.updated_at, a.author_id
+               ORDER BY a.created_at DESC
              """
         .as[Query[ArticleRow]]
         .drop(lift(pagination.offset))
         .take(lift(pagination.limit))
-        .sortBy(ar => ar.slug)
     }
 
     val articleQuery = viewerIdOpt match


### PR DESCRIPTION
According to [Spec](https://www.realworld.how/docs/specs/backend-specs/endpoints#list-articles) articles should be returned by newest first and not ordered by slug. 

Ordering by slug also doesn't really make sense with pagination.
